### PR TITLE
add better initial state to all editor fields

### DIFF
--- a/src/components/artistas/ArtistaForm.jsx
+++ b/src/components/artistas/ArtistaForm.jsx
@@ -11,7 +11,7 @@ import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
 
 import Uploads from '../fields/Uploads';
 
-import ParseEditorContent from '../../utilities/editor.js';
+import { ParseEditorContent, emptyEditorState } from '../../utilities/editor';
 import EMOJIS from '../../utilities/emojis.js';
 
 import { ToastrOptionsSuccess, ToastrOptionsError } from '../../utilities/toastr.js';
@@ -27,9 +27,9 @@ class ArtistaForm extends Component {
     gallery: '',
     galleryUrl: '',
     bioEditorState: '',
-    bioRawContent: '',
+    bioRawContent: emptyEditorState,
     cvEditorState: '',
-    cvRawContent: '',
+    cvRawContent: emptyEditorState,
     images: [],
     video: {
       url: '',

--- a/src/components/noticias/NoticiaForm.jsx
+++ b/src/components/noticias/NoticiaForm.jsx
@@ -14,7 +14,7 @@ import 'react-datepicker/dist/react-datepicker.css';
 import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
 
 import Uploads from '../fields/Uploads';
-import ParseEditorContent from '../../utilities/editor';
+import { ParseEditorContent, emptyEditorState } from '../../utilities/editor';
 import EMOJIS from '../../utilities/emojis';
 
 import { ToastrOptionsSuccess, ToastrOptionsError } from '../../utilities/toastr.js';
@@ -28,7 +28,7 @@ class NoticiaForm extends Component {
     publishDate: '',
     title: '',
     editorState: '',
-    rawContent: '',
+    rawContent: emptyEditorState,
     images: [],
     video: {
       url: '',

--- a/src/components/obras/ObraForm.jsx
+++ b/src/components/obras/ObraForm.jsx
@@ -15,7 +15,7 @@ import { Editor } from 'react-draft-wysiwyg';
 import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
 
 import Uploads from '../fields/Uploads';
-import ParseEditorContent from '../../utilities/editor.js';
+import { ParseEditorContent, emptyEditorState } from '../../utilities/editor';
 import EMOJIS from '../../utilities/emojis.js';
 import { TECNICAS } from '../../utilities/constants.js';
 
@@ -31,7 +31,7 @@ class ObraForm extends Component {
     dimensions: '',
     tecnica: '',
     notesEditorState: '',
-    notesRawContent: '',
+    notesRawContent: emptyEditorState,
     images: [],
     error: {
       message: '',

--- a/src/utilities/editor.js
+++ b/src/utilities/editor.js
@@ -1,6 +1,6 @@
 import { convertFromRaw, EditorState } from 'draft-js';
 
-const ParseEditorContent = (rawContent)  => {
+export const ParseEditorContent = (rawContent)  => {
 
   if (rawContent) {
     // Convert JSON for Editor and create with content
@@ -14,4 +14,17 @@ const ParseEditorContent = (rawContent)  => {
   }
 }
 
-export default ParseEditorContent;
+export const emptyEditorState = JSON.stringify({
+  "entityMap": {},
+  "blocks": [
+    {
+      "key": "3l1mm",
+      "text": "",
+      "type": "unstyled",
+      "depth": 0,
+      "inlineStyleRanges": [],
+      "entityRanges": [],
+      "data": {}
+    }
+  ]
+});


### PR DESCRIPTION
I'm fixing this because an empty string as the initial state for editors was breaking the client app. 

In the case when an entry is created without content on the editor field, and the editor isn't touched at all, the empty string `''` was breaking the client app, especifically the parsing of content. 