### PR TITLE
Feature: Lote group edit order

### DIFF
--- a/src/components/catalogos/CatalogoForm.jsx
+++ b/src/components/catalogos/CatalogoForm.jsx
@@ -161,9 +161,33 @@ class CatalogoForm extends Component {
   }
 
   moveLoteDownGroup(id) {
-    console.log('down', id);
+    // get lote to move index
+    const loteIndex = this.state.lotes.findIndex(lote => {
+      return id === lote.id;
+    });
 
+    // get all lotes and the lote object to move
+    const lotes = this.state.lotes;
+    const lote = lotes[loteIndex];
 
+    // if last it can't go down
+    if (loteIndex === (lotes.length - 1)) {
+      return;
+    }
+
+    // set our target index
+    const targetIndex = loteIndex + 1;
+
+    // remove lote to move from array
+    const lotesFiltered = lotes.filter(lote => lote.id !== id);
+
+    // splice back in lote to move
+    lotesFiltered.splice(targetIndex, 0, lote);
+
+    // return new state
+    this.setState( currentState => ({
+      lotes: lotesFiltered
+    }));
   }
 
   removeLoteFromGroup(id) {

--- a/src/components/catalogos/CatalogoForm.jsx
+++ b/src/components/catalogos/CatalogoForm.jsx
@@ -40,10 +40,7 @@ class CatalogoForm extends Component {
     this.handleSaleDateChange = this.handleSaleDateChange.bind(this);
     this.handleEndDateChange = this.handleEndDateChange.bind(this);
 
-    this.addLoteToGroup = this.addLoteToGroup.bind(this);
-    this.moveLoteUpGroup = this.moveLoteUpGroup.bind(this);
-    this.moveLoteDownGroup = this.moveLoteDownGroup.bind(this);
-    this.removeLoteFromGroup = this.removeLoteFromGroup.bind(this);
+    this.handleOnGroupChange = this.handleOnGroupChange.bind(this);
 
   }
 
@@ -115,85 +112,8 @@ class CatalogoForm extends Component {
 
   }
 
-  addLoteToGroup(selectedLote) {
-    const newLote = {
-      id: selectedLote.id,
-      artista: {
-        id: selectedLote.artista.id,
-        name: selectedLote.artista.name,
-      },
-      title: selectedLote.title,
-    };
-
-    this.setState({
-      lotes: [...this.state.lotes, newLote]
-    });
-  }
-
-  moveLoteUpGroup(id) {
-    // get lote to move index
-    const loteIndex = this.state.lotes.findIndex(lote => {
-      return id === lote.id;
-    });
-
-    // if first it can't go up
-    if (loteIndex === 0) {
-      return;
-    }
-
-    // set our target index
-    const targetIndex = loteIndex - 1;
-
-    // get all lotes and the lote object to move
-    const lotes = this.state.lotes;
-    const lote = lotes[loteIndex];
-
-    // remove lote to move from array
-    const lotesFiltered = lotes.filter(lote => lote.id !== id);
-
-    // splice back in lote to move
-    lotesFiltered.splice(targetIndex, 0, lote);
-
-    // return new state
-    this.setState( currentState => ({
-      lotes: lotesFiltered
-    }));
-  }
-
-  moveLoteDownGroup(id) {
-    // get lote to move index
-    const loteIndex = this.state.lotes.findIndex(lote => {
-      return id === lote.id;
-    });
-
-    // get all lotes and the lote object to move
-    const lotes = this.state.lotes;
-    const lote = lotes[loteIndex];
-
-    // if last it can't go down
-    if (loteIndex === (lotes.length - 1)) {
-      return;
-    }
-
-    // set our target index
-    const targetIndex = loteIndex + 1;
-
-    // remove lote to move from array
-    const lotesFiltered = lotes.filter(lote => lote.id !== id);
-
-    // splice back in lote to move
-    lotesFiltered.splice(targetIndex, 0, lote);
-
-    // return new state
-    this.setState( currentState => ({
-      lotes: lotesFiltered
-    }));
-  }
-
-  removeLoteFromGroup(id) {
-    this.setState( currentState => ({
-      lotes: currentState.lotes.filter( lote => lote.id !== id )
-    }));
+  handleOnGroupChange(lotes) {
+    this.setState({ lotes });
   }
 
   handleStartDateChange(date) {
@@ -339,7 +259,7 @@ class CatalogoForm extends Component {
         <div className='grid-row margin-bottom-basic'>
           <div className='grid-item item-s-12'>
             <h4 className='font-size-small font-bold margin-bottom-tiny'><label htmlFor='lotes'>Lotes</label></h4>
-            <LotesGroupContainer addLoteToGroup={this.addLoteToGroup} selectedLotes={this.state.lotes} moveLoteUpGroup={this.moveLoteUpGroup} moveLoteDownGroup={this.moveLoteDownGroup} removeLoteFromGroup={this.removeLoteFromGroup} />
+            <LotesGroupContainer selectedLotes={this.state.lotes} onChange={this.handleOnGroupChange} />
           </div>
         </div>
 

--- a/src/components/catalogos/CatalogoForm.jsx
+++ b/src/components/catalogos/CatalogoForm.jsx
@@ -131,11 +131,39 @@ class CatalogoForm extends Component {
   }
 
   moveLoteUpGroup(id) {
-    console.log('up', id);
+    // get lote to move index
+    const loteIndex = this.state.lotes.findIndex(lote => {
+      return id === lote.id;
+    });
+
+    // if first it can't go up
+    if (loteIndex === 0) {
+      return;
+    }
+
+    // set our target index
+    const targetIndex = loteIndex - 1;
+
+    // get all lotes and the lote object to move
+    const lotes = this.state.lotes;
+    const lote = lotes[loteIndex];
+
+    // remove lote to move from array
+    const lotesFiltered = lotes.filter(lote => lote.id !== id);
+
+    // splice back in lote to move
+    lotesFiltered.splice(targetIndex, 0, lote);
+
+    // return new state
+    this.setState( currentState => ({
+      lotes: lotesFiltered
+    }));
   }
 
   moveLoteDownGroup(id) {
     console.log('down', id);
+
+
   }
 
   removeLoteFromGroup(id) {

--- a/src/components/catalogos/CatalogoForm.jsx
+++ b/src/components/catalogos/CatalogoForm.jsx
@@ -39,7 +39,10 @@ class CatalogoForm extends Component {
     this.handleStartDateChange = this.handleStartDateChange.bind(this);
     this.handleSaleDateChange = this.handleSaleDateChange.bind(this);
     this.handleEndDateChange = this.handleEndDateChange.bind(this);
+
     this.addLoteToGroup = this.addLoteToGroup.bind(this);
+    this.moveLoteUpGroup = this.moveLoteUpGroup.bind(this);
+    this.moveLoteDownGroup = this.moveLoteDownGroup.bind(this);
     this.removeLoteFromGroup = this.removeLoteFromGroup.bind(this);
 
   }
@@ -125,6 +128,14 @@ class CatalogoForm extends Component {
     this.setState({
       lotes: [...this.state.lotes, newLote]
     });
+  }
+
+  moveLoteUpGroup(id) {
+    console.log('up', id);
+  }
+
+  moveLoteDownGroup(id) {
+    console.log('down', id);
   }
 
   removeLoteFromGroup(id) {
@@ -276,7 +287,7 @@ class CatalogoForm extends Component {
         <div className='grid-row margin-bottom-basic'>
           <div className='grid-item item-s-12'>
             <h4 className='font-size-small font-bold margin-bottom-tiny'><label htmlFor='lotes'>Lotes</label></h4>
-            <LotesGroupContainer addLoteToGroup={this.addLoteToGroup} selectedLotes={this.state.lotes} removeLoteFromGroup={this.removeLoteFromGroup} />
+            <LotesGroupContainer addLoteToGroup={this.addLoteToGroup} selectedLotes={this.state.lotes} moveLoteUpGroup={this.moveLoteUpGroup} moveLoteDownGroup={this.moveLoteDownGroup} removeLoteFromGroup={this.removeLoteFromGroup} />
           </div>
         </div>
 

--- a/src/components/lotes/LotesGroup.jsx
+++ b/src/components/lotes/LotesGroup.jsx
@@ -26,6 +26,14 @@ class LotesGroup extends Component {
     this.props.addLoteToGroup(selectedLote);
   }
 
+  moveLoteUpGroup(id) {
+    this.props.moveLoteUpGroup(id);
+  }
+
+  moveLoteDownGroup(id) {
+    this.props.moveLoteDownGroup(id);
+  }
+
   removeLoteFromGroup(id) {
     this.props.removeLoteFromGroup(id);
   }
@@ -57,7 +65,7 @@ class LotesGroup extends Component {
   }
 
   render() {
-    const { allLotes, selectedLotes, removeLoteFromGroup } = this.props;
+    const { allLotes, selectedLotes, moveLoteUpGroup, moveLoteDownGroup, removeLoteFromGroup } = this.props;
     const filteredLotes = this.filterLotes(allLotes, selectedLotes);
 
     if (!isLoaded(allLotes)) { // If not loaded…
@@ -65,9 +73,18 @@ class LotesGroup extends Component {
     } else {
       return (
         <div>
-          <div className='grid-row padding-top-micro padding-bottom-basic align-items-center'>
+          <header className='grid-row margin-bottom-tiny font-size-small font-bold'>
+            <div className='grid-item item-s-3 item-m-5'>
+              <h3>Título</h3>
+            </div>
+            <div className='grid-item item-s-3'>
+              <h3>Artista</h3>
+            </div>
+          </header>
+
+          <div className='lote-group-list-holder'>
             { selectedLotes.map(lote =>
-              <LotesGroupItem key={lote.id} lote={lote} removeLoteFromGroup={removeLoteFromGroup} />
+              <LotesGroupItem key={lote.id} lote={lote} moveLoteUpGroup={moveLoteUpGroup} moveLoteDownGroup={moveLoteDownGroup} removeLoteFromGroup={removeLoteFromGroup} />
             )}
           </div>
           { isEmpty(filteredLotes) ? '' :
@@ -91,6 +108,8 @@ class LotesGroup extends Component {
 LotesGroup.propTypes = {
   addLoteToGroup: PropTypes.func.isRequired,
   allLotes: PropTypes.array,
+  moveLoteUpGroup: PropTypes.func.isRequired,
+  moveLoteDownGroup: PropTypes.func.isRequired,
   removeLoteFromGroup: PropTypes.func.isRequired,
   selectedLotes: PropTypes.array,
 };

--- a/src/components/lotes/LotesGroup.jsx
+++ b/src/components/lotes/LotesGroup.jsx
@@ -18,24 +18,61 @@ class LotesGroup extends Component {
     // Bind
     this.handleSelectChange = this.handleSelectChange.bind(this);
     this.addLoteToGroup = this.addLoteToGroup.bind(this);
+    this.moveLoteUp = this.moveLoteUp.bind(this);
+    this.moveLoteDown = this.moveLoteDown.bind(this);
+    this.removeLoteFromGroup = this.removeLoteFromGroup.bind(this);
+
   }
 
   addLoteToGroup() {
     const selectedLote = this.state.selectedLote;
 
-    this.props.addLoteToGroup(selectedLote);
-  }
+    const newLote = {
+      id: selectedLote.id,
+      artista: {
+        id: selectedLote.artista.id,
+        name: selectedLote.artista.name,
+      },
+      title: selectedLote.title,
+    };
 
-  moveLoteUpGroup(id) {
-    this.props.moveLoteUpGroup(id);
-  }
-
-  moveLoteDownGroup(id) {
-    this.props.moveLoteDownGroup(id);
+    this.props.onChange([...this.props.selectedLotes, newLote]);
   }
 
   removeLoteFromGroup(id) {
-    this.props.removeLoteFromGroup(id);
+    this.props.onChange(this.props.selectedLotes.filter( lote => lote.id !== id ));
+  }
+
+  moveLote(element, delta) {
+    const lotes = this.props.selectedLotes;
+    const index = lotes.indexOf(element);
+    const newIndex = index + delta;
+
+    // Check if lready at the top or bottom.
+    if (newIndex < 0  || newIndex === lotes.length) {
+      return lotes;
+    }
+
+    let indexes = [index, newIndex]; //Sort the indexes
+
+    return lotes.map( (item,index) => {
+      if(index === indexes[0]) {
+        return lotes[indexes[1]];
+      } else if(index === indexes[1]) {
+        return lotes[indexes[0]];
+      } else {
+        return item;
+      }
+    });
+
+  }
+
+  moveLoteUp(lote) {
+    this.props.onChange(this.moveLote(lote, -1));
+  }
+
+  moveLoteDown(lote) {
+    this.props.onChange(this.moveLote(lote, 1));
   }
 
   handleSelectChange(event) {
@@ -65,8 +102,8 @@ class LotesGroup extends Component {
   }
 
   render() {
-    const { allLotes, selectedLotes, moveLoteUpGroup, moveLoteDownGroup, removeLoteFromGroup } = this.props;
-    const filteredLotes = this.filterLotes(allLotes, selectedLotes);
+    const { allLotes, selectedLotes } = this.props;
+    const availableLotes = this.filterLotes(allLotes, selectedLotes);
 
     if (!isLoaded(allLotes)) { // If not loaded…
       return 'Loading'; // …show 'loading'
@@ -83,15 +120,15 @@ class LotesGroup extends Component {
           </header>
 
           <div className='lote-group-list-holder'>
-            { selectedLotes.map(lote =>
-              <LotesGroupItem key={lote.id} lote={lote} moveLoteUpGroup={moveLoteUpGroup} moveLoteDownGroup={moveLoteDownGroup} removeLoteFromGroup={removeLoteFromGroup} />
+            { selectedLotes.map( (lote, index) =>
+              <LotesGroupItem key={lote.id} lote={lote} moveLoteUp={this.moveLoteUp} moveLoteDown={this.moveLoteDown} removeLoteFromGroup={this.removeLoteFromGroup} upDisabled={index === 0 ? 'disabled' : ''} downDisabled={index === selectedLotes.length - 1 ? 'disabled' : ''} />
             )}
           </div>
-          { isEmpty(filteredLotes) ? '' :
+          { isEmpty(availableLotes) ? '' :
             <div className='grid-row padding-bottom-basic'>
               <select onChange={this.handleSelectChange} className='grid-item item-s-12 item-m-4'>
                 <option value=''></option>
-                { filteredLotes.map(lote =>
+                { availableLotes.map(lote =>
                   <option key={lote.key} value={lote.key}>{lote.value.artista.name} - {lote.value.title}</option>
                 ) }
               </select>
@@ -106,11 +143,8 @@ class LotesGroup extends Component {
 };
 
 LotesGroup.propTypes = {
-  addLoteToGroup: PropTypes.func.isRequired,
+  onChange: PropTypes.func.isRequired,
   allLotes: PropTypes.array,
-  moveLoteUpGroup: PropTypes.func.isRequired,
-  moveLoteDownGroup: PropTypes.func.isRequired,
-  removeLoteFromGroup: PropTypes.func.isRequired,
   selectedLotes: PropTypes.array,
 };
 

--- a/src/components/lotes/LotesGroupItem.jsx
+++ b/src/components/lotes/LotesGroupItem.jsx
@@ -1,13 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types'; // ES6
 
-const LoteGroupItem = ({ lote, removeLoteFromGroup }) => {
-  const { artista, title } = lote;
+import { Link } from 'react-router-dom';
+
+const LoteGroupItem = ({ lote, moveLoteUpGroup, moveLoteDownGroup, removeLoteFromGroup }) => {
+  const { id, artista, title } = lote;
 
   return(
-    <div className='grid-item item-s-3'>
-      <h3>{artista.name} - {title}</h3>
-      <button type='button' onClick={() => removeLoteFromGroup(lote.id)} className='button button-small button-delete'>Retirar</button>
+    <div className='list-rows-item grid-row padding-top-micro padding-bottom-micro align-items-center'>
+      <div className='grid-item item-s-3 item-m-5'>
+        <span><Link className="link-underline" to={'/lotes/' + id}>{title}</Link></span>
+      </div>
+      <div className='grid-item item-s-3'>
+        <span>{artista.name}</span>
+      </div>
+      <div className='grid-item flex-grow grid-row no-gutter justify-end'>
+        <div className='grid-item'>
+          <button type='button' onClick={() => moveLoteUpGroup(lote.id)} className='button button-small'>Up</button>
+          <button type='button' onClick={() => moveLoteDownGroup(lote.id)} className='button button-small'>Down</button>
+          <button type='button' onClick={() => removeLoteFromGroup(lote.id)} className='button button-small button-delete'>Retirar</button>
+        </div>
+      </div>
     </div>
   );
 }
@@ -17,6 +30,8 @@ LoteGroupItem.propTypes = {
     title: PropTypes.string.isRequired,
     artista: PropTypes.object,
   }).isRequired,
+  moveLoteUpGroup: PropTypes.func.isRequired,
+  moveLoteDownGroup: PropTypes.func.isRequired,
   removeLoteFromGroup: PropTypes.func.isRequired,
 };
 

--- a/src/components/lotes/LotesGroupItem.jsx
+++ b/src/components/lotes/LotesGroupItem.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'; // ES6
 
 import { Link } from 'react-router-dom';
 
-const LoteGroupItem = ({ lote, moveLoteUpGroup, moveLoteDownGroup, removeLoteFromGroup }) => {
+const LoteGroupItem = ({ lote, moveLoteUp, moveLoteDown, removeLoteFromGroup, upDisabled, downDisabled }) => {
   const { id, artista, title } = lote;
 
   return(
@@ -16,8 +16,8 @@ const LoteGroupItem = ({ lote, moveLoteUpGroup, moveLoteDownGroup, removeLoteFro
       </div>
       <div className='grid-item flex-grow grid-row no-gutter justify-end'>
         <div className='grid-item'>
-          <button type='button' onClick={() => moveLoteUpGroup(lote.id)} className='button button-small'>Up</button>
-          <button type='button' onClick={() => moveLoteDownGroup(lote.id)} className='button button-small'>Down</button>
+          <button type='button' onClick={() => moveLoteUp(lote)} disabled={upDisabled} className='button button-small'>↑</button>
+          <button type='button' onClick={() => moveLoteDown(lote)} disabled={downDisabled} className='button button-small'>↓</button>
           <button type='button' onClick={() => removeLoteFromGroup(lote.id)} className='button button-small button-delete'>Retirar</button>
         </div>
       </div>
@@ -30,8 +30,8 @@ LoteGroupItem.propTypes = {
     title: PropTypes.string.isRequired,
     artista: PropTypes.object,
   }).isRequired,
-  moveLoteUpGroup: PropTypes.func.isRequired,
-  moveLoteDownGroup: PropTypes.func.isRequired,
+  moveLoteUp: PropTypes.func.isRequired,
+  moveLoteDown: PropTypes.func.isRequired,
   removeLoteFromGroup: PropTypes.func.isRequired,
 };
 

--- a/src/containers/lotes/LotesGroupContainer.jsx
+++ b/src/containers/lotes/LotesGroupContainer.jsx
@@ -6,8 +6,8 @@ import { firebaseConnect } from 'react-redux-firebase';
 
 import LotesGroup from '../../components/lotes/LotesGroup';
 
-const LotesGroupContainer = ({ addLoteToGroup, allLotes, selectedLotes, removeLoteFromGroup }) => (
-  <LotesGroup allLotes={allLotes} addLoteToGroup={addLoteToGroup} selectedLotes={selectedLotes} removeLoteFromGroup={removeLoteFromGroup}/>
+const LotesGroupContainer = ({ addLoteToGroup, allLotes, selectedLotes, moveLoteUpGroup, moveLoteDownGroup, removeLoteFromGroup }) => (
+  <LotesGroup allLotes={allLotes} addLoteToGroup={addLoteToGroup} selectedLotes={selectedLotes} moveLoteUpGroup={moveLoteUpGroup} moveLoteDownGroup={moveLoteDownGroup} removeLoteFromGroup={removeLoteFromGroup}/>
 );
 
 LotesGroupContainer.propTypes = {

--- a/src/containers/lotes/LotesGroupContainer.jsx
+++ b/src/containers/lotes/LotesGroupContainer.jsx
@@ -6,14 +6,13 @@ import { firebaseConnect } from 'react-redux-firebase';
 
 import LotesGroup from '../../components/lotes/LotesGroup';
 
-const LotesGroupContainer = ({ addLoteToGroup, allLotes, selectedLotes, moveLoteUpGroup, moveLoteDownGroup, removeLoteFromGroup }) => (
-  <LotesGroup allLotes={allLotes} addLoteToGroup={addLoteToGroup} selectedLotes={selectedLotes} moveLoteUpGroup={moveLoteUpGroup} moveLoteDownGroup={moveLoteDownGroup} removeLoteFromGroup={removeLoteFromGroup}/>
+const LotesGroupContainer = ({ allLotes, selectedLotes, onChange }) => (
+  <LotesGroup allLotes={allLotes} selectedLotes={selectedLotes} onChange={onChange} />
 );
 
 LotesGroupContainer.propTypes = {
-  addLoteToGroup: PropTypes.func.isRequired,
+  onChange: PropTypes.func.isRequired,
   allLotes: PropTypes.array,
-  removeLoteFromGroup: PropTypes.func.isRequired,
   selectedLotes: PropTypes.array,
 };
 

--- a/src/styl/responsive/mobile.styl
+++ b/src/styl/responsive/mobile.styl
@@ -37,6 +37,9 @@ a.button
     padding: ($margin-tiny*0.8) $margin-tiny
   &.button-delete
     background-color: $color-button-warning
+  &:disabled
+    background-color: $color-button-disabled
+    cursor: default;
 
 .list-rows-holder
   > *


### PR DESCRIPTION
I don't really like how this has to work as feel the function to move these values should be deeper inside the LotesGroup components or container not in the `CatalogoForm`. But this is the pattern we are generally using and I somewhat understand why (could it really not be in the container tho and pass the array back up to the form?).

I imagine we can reuse this code for the other groups if it is any good.