### PR TITLE
fix change BrowserRouter for HashRouter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 //eslint-disable import/first
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { HashRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { createStoreWithFirebase } from './firebase';
 


### PR DESCRIPTION
We need this switch because the static hosting of firebase. If you go to a route that is not `/` and refresh the page it returns a 404. More about it here https://stackoverflow.com/a/36623117